### PR TITLE
hit test 를 통해 터치를 무시시키기

### DIFF
--- a/JLToast/JLToastView.m
+++ b/JLToast/JLToastView.m
@@ -100,4 +100,12 @@
 	self.frame = CGRectMake( x, y, width, height );
 }
 
+#pragma mark - hit test
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    //    NSLog(@"%@ hitTest", [self class]);
+    return nil;
+}
+
 @end


### PR DESCRIPTION
알림이 떠 있는 동안 그 아래에 터치를 하고 싶을 경우가 많은데 JLToastView가 터치를 흡수해버리기 때문에 무시하고 아래 터치를 할 수 있게 해주는 소스를 추가
