### PR TITLE
Add support for settings default values.

### DIFF
--- a/JLToast/JLToast.h
+++ b/JLToast/JLToast.h
@@ -16,6 +16,9 @@
  */
 
 #if __OBJC__
-    static const NSTimeInterval JLToastShortDelay = 2.0;
-    static const NSTimeInterval JLToastLongDelay = 3.5;
+static NSTimeInterval const JLToastShortDelay = 2.0;
+static NSTimeInterval const JLToastLongDelay = 3.5;
+static NSString * const JLToastViewFontSizeAttributeName = @"JLToastViewFontSizeAttributeName";
+static NSString * const JLToastViewPortraitOffsetYAttributeName = @"JLToastViewPortraitOffsetYAttributeName";
+static NSString * const JLToastViewLandscapeOffsetYAttributeName = @"JLToastViewLandscapeOffsetYAttributeName";
 #endif

--- a/JLToast/JLToast.swift
+++ b/JLToast/JLToast.swift
@@ -24,20 +24,6 @@ public struct JLToastDelay {
     public static let LongDelay: NSTimeInterval = 3.5
 }
 
-public struct JLToastViewValue {
-    static var FontSize: CGFloat {
-        return UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone ? 12 : 16
-    }
-    
-    static var PortraitOffsetY: CGFloat {
-        return UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone ? 30 : 60
-    }
-    
-    static var LandscapeOffsetY: CGFloat {
-        return UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone ? 20 : 40
-    }
-}
-
 @objc public class JLToast: NSOperation {
 
     public var view: JLToastView = JLToastView()

--- a/JLToast/JLToastView.swift
+++ b/JLToast/JLToastView.swift
@@ -19,6 +19,10 @@
 
 import UIKit
 
+public let JLToastViewFontSizeAttributeName = "JLToastViewFontSizeAttributeName"
+public let JLToastViewPortraitOffsetYAttributeName = "JLToastViewPortraitOffsetYAttributeName"
+public let JLToastViewLandscapeOffsetYAttributeName = "JLToastViewLandscapeOffsetYAttributeName"
+
 @objc public class JLToastView: UIView {
     
     var backgroundView: UIView!
@@ -27,6 +31,12 @@ import UIKit
     
     override init() {
         super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+        let userInterfaceIdiom = UIDevice.currentDevice().userInterfaceIdiom
+        let fontSize = self.dynamicType.defaultValueForAttributeName(
+            JLToastViewFontSizeAttributeName,
+            forUserInterfaceIdiom: userInterfaceIdiom
+        )
 
         self.backgroundView = UIView()
         self.backgroundView.frame = self.bounds
@@ -39,7 +49,7 @@ import UIKit
         self.textLabel.frame = self.bounds
         self.textLabel.textColor = UIColor.whiteColor()
         self.textLabel.backgroundColor = UIColor.clearColor()
-        self.textLabel.font = UIFont.systemFontOfSize(JLToastViewValue.FontSize)
+        self.textLabel.font = UIFont.systemFontOfSize(fontSize)
         self.textLabel.numberOfLines = 0
         self.textLabel.textAlignment = .Center;
         self.addSubview(self.textLabel)
@@ -78,17 +88,27 @@ import UIKit
         let orientation = UIApplication.sharedApplication().statusBarOrientation
         let systemVersion = (UIDevice.currentDevice().systemVersion as NSString).floatValue
 
+        let userInterfaceIdiom = UIDevice.currentDevice().userInterfaceIdiom
+        let portraitOffsetY = self.dynamicType.defaultValueForAttributeName(
+            JLToastViewPortraitOffsetYAttributeName,
+            forUserInterfaceIdiom: userInterfaceIdiom
+        )
+        let landscapeOffsetY = self.dynamicType.defaultValueForAttributeName(
+            JLToastViewLandscapeOffsetYAttributeName,
+            forUserInterfaceIdiom: userInterfaceIdiom
+        )
+
         if UIInterfaceOrientationIsLandscape(orientation) && systemVersion < 8.0 {
             width = screenSize.height
             height = screenSize.width
-            y = JLToastViewValue.LandscapeOffsetY
+            y = landscapeOffsetY
         } else {
             width = screenSize.width
             height = screenSize.height
             if UIInterfaceOrientationIsLandscape(orientation) {
-                y = JLToastViewValue.LandscapeOffsetY
+                y = landscapeOffsetY
             } else {
-                y = JLToastViewValue.PortraitOffsetY
+                y = portraitOffsetY
             }
         }
 
@@ -99,5 +119,39 @@ import UIKit
     
     override public func hitTest(point: CGPoint, withEvent event: UIEvent!) -> UIView? {
         return nil
+    }
+
+}
+
+public extension JLToastView {
+    private struct Singleton {
+        static var defaultValues: [String: [UIUserInterfaceIdiom: CGFloat]] = [
+            JLToastViewFontSizeAttributeName: [
+                .Phone: 12,
+                .Pad: 16,
+            ],
+            JLToastViewPortraitOffsetYAttributeName: [
+                .Phone: 30,
+                .Pad: 60,
+            ],
+            JLToastViewLandscapeOffsetYAttributeName: [
+                .Phone: 20,
+                .Pad: 40,
+            ],
+        ]
+    }
+
+    class func defaultValueForAttributeName(attributeName: String,
+                                            forUserInterfaceIdiom userInterfaceIdiom: UIUserInterfaceIdiom)
+                                            -> CGFloat {
+        return Singleton.defaultValues[attributeName]![userInterfaceIdiom]!
+    }
+
+    class func setDefaultValue(value: CGFloat,
+                               forAttributeName attributeName: String,
+                               userInterfaceIdiom: UIUserInterfaceIdiom) {
+        var values = Singleton.defaultValues[attributeName]!
+        values[userInterfaceIdiom] = value
+        Singleton.defaultValues[attributeName] = values
     }
 }


### PR DESCRIPTION
Now you can set default values for `JLToastView` appearance. Since swift doesn't support `UIAppearance` yet, we have to set default values with: 

```objc
+ [JLToastView setDefaultValue:forAttributeName:userInterfaceIdiom:]
```

#### Examples

Setting default font size to 20:

**Swift**
```swift
JLToastView.setDefaultValue(20, forAttributeName: JLToastViewFontSizeAttributeName, userInterfaceIdiom: .Phone)
```

**Objective-C**
```objc
[JLToastView setDefaultValue:20
            forAttributeName:JLToastViewFontSizeAttributeName
          userInterfaceIdiom:UIUserInterfaceIdiomPhone];
```
