### PR TITLE
fix: remove 'override' keyword from init()

### DIFF
--- a/JLToast/JLToastView.swift
+++ b/JLToast/JLToastView.swift
@@ -33,7 +33,7 @@ public let JLToastViewLandscapeOffsetYAttributeName = "JLToastViewLandscapeOffse
     var textLabel: UILabel!
     var textInsets: UIEdgeInsets!
     
-    override init() {
+    init() {
         super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
 
         let userInterfaceIdiom = UIDevice.currentDevice().userInterfaceIdiom


### PR DESCRIPTION
Just found another compiler error in XCode 6.3 Beta 3, please have a look :)

* Starting from Swift 1.2, 'override' keyword is only allowed when overriding a designated initializer.