### PR TITLE
Add JLToast to `UITextEffectsWindow`.

### DIFF
--- a/JLToast/JLToast.swift
+++ b/JLToast/JLToast.swift
@@ -63,6 +63,15 @@ public struct JLToastDelay {
             self.didChangeValueForKey("isFinished")
         }
     }
+
+    internal var window: UIWindow {
+        for window in UIApplication.sharedApplication().windows as? [UIWindow] ?? [] {
+            if NSStringFromClass(window.dynamicType) == "UITextEffectsWindow" {
+                return window
+            }
+        }
+        return UIApplication.sharedApplication().windows.first as! UIWindow
+    }
     
     
     public class func makeText(text: String) -> JLToast {
@@ -101,7 +110,7 @@ public struct JLToastDelay {
         dispatch_async(dispatch_get_main_queue(), {
             self.view.updateView()
             self.view.alpha = 0
-            UIApplication.sharedApplication().windows.first?.addSubview(self.view)
+            self.window.addSubview(self.view)
             UIView.animateWithDuration(
                 0.5,
                 delay: self.delay,
@@ -131,4 +140,5 @@ public struct JLToastDelay {
         self.executing = false
         self.finished = true
     }
+
 }


### PR DESCRIPTION
Add `JLToastView` to `UITextEffectsWindow`. If `UITextEffectsWindow` not exists for some reason, add to first window of application.

- Related issue: #31

#### Preview

![ios simulator screen shot jul 29 2015 11 44 20 pm](https://cloud.githubusercontent.com/assets/931655/8960639/e1226678-364b-11e5-9524-7d05a696b15d.png)