### PR TITLE
Fix a bug that toast view located behind the keyboard in iOS 9

### DIFF
--- a/JLToast/JLToast.swift
+++ b/JLToast/JLToast.swift
@@ -65,12 +65,14 @@ public struct JLToastDelay {
     }
 
     internal var window: UIWindow {
-        for window in UIApplication.sharedApplication().windows {
-            if NSStringFromClass(window.dynamicType) == "UITextEffectsWindow" {
+        let windows = UIApplication.sharedApplication().windows
+        for window in windows.reverse() {
+            let className = NSStringFromClass(window.dynamicType)
+            if className == "UIRemoteKeyboardWindow" || className == "UITextEffectsWindow" {
                 return window
             }
         }
-        return UIApplication.sharedApplication().windows.first!
+        return windows.first!
     }
     
     


### PR DESCRIPTION
- There's an `UIRemoteKeyboardWindow` on the `UITextEffectsWindow` window.
- Related issue: #31 (@ArtworkAD)
