### PR TITLE
Set window background color as clear color.

### DIFF
--- a/JLToast/JLToastWindow.swift
+++ b/JLToast/JLToastWindow.swift
@@ -25,6 +25,7 @@ public class JLToastWindow: UIWindow {
         let window = JLToastWindow(frame: UIScreen.mainScreen().bounds)
         window.userInteractionEnabled = false
         window.windowLevel = CGFloat.max
+        window.backgroundColor = .clearColor()
         window.rootViewController = JLToastWindowRootViewController()
         window.hidden = false
         return window
@@ -58,6 +59,11 @@ private class JLToastWindowRootViewController: UIViewController {
 
     private convenience init() {
         self.init(nibName: nil, bundle: nil)
+    }
+
+    private override func viewDidLoad() {
+        super.viewDidLoad()
+//        self.view.backgroundColor = UIColor.greenColor().colorWithAlphaComponent(0)
     }
 
     private override func preferredStatusBarStyle() -> UIStatusBarStyle {


### PR DESCRIPTION
- Fix #58
- Solution: http://stackoverflow.com/questions/19782944/blacked-out-interface-rotation-when-using-second-uiwindow-with-rootviewcontrolle#comment45655591_27260717
