### PR TITLE
enable to cancel to be showing or scheduled to be shown toasts

### DIFF
--- a/JLToast/JLToast.swift
+++ b/JLToast/JLToast.swift
@@ -87,10 +87,10 @@ public struct JLToastDelay {
     override public func start() {
         if !NSThread.isMainThread() {
             dispatch_async(dispatch_get_main_queue(), {
-                self.start()
+                self.main()
             })
         } else {
-            super.start()
+            self.main()
         }
     }
 

--- a/JLToast/JLToastCenter.swift
+++ b/JLToast/JLToastCenter.swift
@@ -47,6 +47,10 @@ import UIKit
         self._queue.addOperation(toast)
     }
     
+    public func cancelAllToasts() {
+        self._queue.cancelAllOperations()
+    }
+
     func deviceOrientationDidChange(sender: AnyObject?) {
         if self._queue.operations.count > 0 {
             let lastToast: JLToast = _queue.operations[0] as! JLToast

--- a/JLToastDemo/AppDelegate.swift
+++ b/JLToastDemo/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.backgroundColor = UIColor.whiteColor()
-        self.window!.rootViewController = RootViewController()
+        self.window!.rootViewController = UINavigationController(rootViewController: RootViewController())
         self.window!.makeKeyAndVisible()
         return true
     }

--- a/JLToastDemo/RootViewController.swift
+++ b/JLToastDemo/RootViewController.swift
@@ -21,15 +21,65 @@ import UIKit
 import JLToast
 
 class RootViewController: UIViewController {
-
     override func viewDidLoad() {
         let button = UIButton(type: .System)
         button.setTitle("Show", forState: .Normal)
         button.sizeToFit()
         button.center.x = self.view.frame.width / 2
-        button.center.y = 60
+        button.center.y = 100
         button.addTarget(self, action: "showButtonTouchUpInside", forControlEvents: UIControlEvents.TouchUpInside)
         self.view.addSubview(button)
+
+        let button2 = UIButton(type: .System)
+        button2.setTitle("Next Page", forState: .Normal)
+        button2.sizeToFit()
+        button2.center.x = self.view.frame.width / 2
+        button2.center.y = button.frame.maxY + 50
+        button2.addTarget(self, action: "nextButtonTouchUpInside", forControlEvents: UIControlEvents.TouchUpInside)
+        self.view.addSubview(button2)
+    }
+
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        JLToast.clear()
+    }
+
+    func showButtonTouchUpInside() {
+        JLToast.makeText("Basic JLToast").show()
+        JLToast.makeText("You can set duration. `JLToastDelay.ShortDelay` means 2 seconds.\n" +
+            "`JLToastDelay.LongDelay` means 3.5 seconds.", duration: JLToastDelay.LongDelay).show()
+        JLToast.makeText("With delay, JLToast will be shown after delay.", delay: 1, duration: 5).show()
+    }
+
+    func nextButtonTouchUpInside() {
+        navigationController?.pushViewController(ToastViewController(), animated: true)
+    }
+}
+
+class ToastViewController: UIViewController {
+    override func viewDidLoad() {
+        view.backgroundColor = UIColor.whiteColor()
+
+        let button = UIButton(type: .System)
+        button.setTitle("Show", forState: .Normal)
+        button.sizeToFit()
+        button.center.x = self.view.frame.width / 2
+        button.center.y = 100
+        button.addTarget(self, action: "showButtonTouchUpInside", forControlEvents: UIControlEvents.TouchUpInside)
+        self.view.addSubview(button)
+
+        let button2 = UIButton(type: .System)
+        button2.setTitle("Cancel", forState: .Normal)
+        button2.sizeToFit()
+        button2.center.x = self.view.frame.width / 2
+        button2.center.y = button.frame.maxY + 50
+        button2.addTarget(self, action: "cancelButtonTouchUpInside", forControlEvents: UIControlEvents.TouchUpInside)
+        self.view.addSubview(button2)
+    }
+
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+        JLToast.clear()
     }
 
     func showButtonTouchUpInside() {
@@ -37,5 +87,9 @@ class RootViewController: UIViewController {
         JLToast.makeText("You can set duration. `JLToastDelay.ShortDelay` means 2 seconds.\n" +
                          "`JLToastDelay.LongDelay` means 3.5 seconds.", duration: JLToastDelay.LongDelay).show()
         JLToast.makeText("With delay, JLToast will be shown after delay.", delay: 1, duration: 5).show()
+    }
+
+    func cancelButtonTouchUpInside() {
+        JLToast.clear()
     }
 }


### PR DESCRIPTION
I'm sorry that I'm not good at English. ><

I want to cancel toasts in switched viewcontrollers.
Or I only want to display a last scheduled toast while toasts is scheduled continuously.

For example, In case of hit count is displayed in search screen every time the search condition is changed.

So I enable to hide showing toasts.

It provides the following methods.

~~~
JLToast.clear()
~~~

Please check this at 'ToastDemo' project for details.


By the way, it is called `start()` again in `start()` 's methods, but I think you should call `main()`.
So I change to do this.

I have this example as a reference.
[ConcurrencyProgrammingGuide](https://developer.apple.com/library/mac/documentation/General/Conceptual/ConcurrencyProgrammingGuide/OperationObjects/OperationObjects.html#//apple_ref/doc/uid/TP40008091-CH101-SW11)