### PR TITLE
Fix typo in license

### DIFF
--- a/JLToast.podspec
+++ b/JLToast.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version      = "1.4.2"
   s.summary      = "Toast UI for Swift - Android-like toast with very simple interface."
   s.homepage     = "http://github.com/devxoul/JLToast"
-  s.license      = { :type => 'WTPFL', :file => 'LICENSE' }
+  s.license      = { :type => 'WTFPL', :file => 'LICENSE' }
   s.author       = { "devxoul" => "devxoul@gmail.com" }
   s.source       = { :git => "https://github.com/devxoul/JLToast.git",
                      :tag => "#{s.version}" }


### PR DESCRIPTION
It's [WTFPL](http://www.wtfpl.net/).